### PR TITLE
Allow null handinput in managed hand class

### DIFF
--- a/source/MagicLeap-Tools/Code/Input/Hands/Objects/ManagedHand.cs
+++ b/source/MagicLeap-Tools/Code/Input/Hands/Objects/ManagedHand.cs
@@ -59,7 +59,10 @@ namespace MagicLeapTools
             Hand = hand;
             Skeleton = new ManagedHandSkeleton(this);
             Gesture = new ManagedHandGesture(this);
-            Collider = new ManagedHandCollider(this);
+            if(handInput != null)
+            {
+                Collider = new ManagedHandCollider(this);
+            }
         }
 
         //Public Methods:
@@ -79,7 +82,10 @@ namespace MagicLeapTools
 
             Skeleton.Update();
             Gesture.Update();
-            Collider.Update(_handInput.palmCollisions);
+            if(_handInput != null)
+            {
+                Collider.Update(_handInput.palmCollisions);
+            }
         }
 #endif
     }


### PR DESCRIPTION
- Hand input is only used to determine if the hand collider should be active, and a null parameter will cause the update loop to break.
- Allowing null hand input means that devs can implement their own hand input manager class for managedHand